### PR TITLE
SAE leadscrew pitch value correction

### DIFF
--- a/RepRapCalculator.html
+++ b/RepRapCalculator.html
@@ -129,7 +129,7 @@ The result is theoreticaly right, but you might still need to calibrate your mac
 	<select name="StepPerMMLeadscrewType" id="StepPerMMLeadscrewType">
 		<option value="1.25">M8 - metric (1.25mm per rotation)</option>
 		<option value="1">M6 - metric (1mm per rotation)</option>
-		<option value="7.02056">5/16 - imperial (7.02056mm per rotation)</option>
+		<option value="1.41">5/16 - SAE (1.41mm per rotation)</option>
 	</select>
 	</p>
 	<p>


### PR DESCRIPTION
Imperial leadscrew pitch is certainly not over 7mm, the value I found in the wiki is 1.41. I did not do the math or test empirically myself, but this value seems very reasonable.
